### PR TITLE
This is the code that is on the 'bot for Norwich.

### DIFF
--- a/TeamCode/build.gradle
+++ b/TeamCode/build.gradle
@@ -13,7 +13,6 @@
 
 // Include common definitions from above.
 repositories{
-    maven { url = "https://repo.dairy.foundation/releases" }
     maven { url = 'https://maven.brott.dev/' }
 }
 buildscript {
@@ -33,7 +32,6 @@ buildscript {
 apply from: '../build.common.gradle'
 apply from: '../build.dependencies.gradle'
 apply plugin: 'org.jetbrains.kotlin.android'
-apply plugin: 'dev.frozenmilk.sinister.sloth.load'
 
 android {
     namespace = 'org.firstinspires.ftc.teamcode'
@@ -53,6 +51,5 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.7'
     implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.4.21'
     implementation 'org.ftclib.ftclib:core:2.1.1'
-    implementation("dev.frozenmilk.sinister:Sloth:0.2.4")
-    implementation("com.acmerobotics.slothboard:dashboard:0.2.4+0.5.1")
+    implementation('com.acmerobotics.dashboard:dashboard:0.5.1')
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/setup/SetAllianceBlue.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/setup/SetAllianceBlue.java
@@ -1,11 +1,13 @@
 package org.firstinspires.ftc.teamcode.opmodes.setup;
 
+import com.qualcomm.robotcore.eventloop.opmode.Disabled;
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
 
 import org.firstinspires.ftc.teamcode.subassemblies.Underglow;
 import org.firstinspires.ftc.teamcode.util.Global;
 
+@Disabled
 @TeleOp(name = "Set Alliance Blue", group = Global.OpModeGroup.SETUP)
 public class SetAllianceBlue extends LinearOpMode {
     @Override

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/setup/SetAllianceRed.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/setup/SetAllianceRed.java
@@ -1,11 +1,13 @@
 package org.firstinspires.ftc.teamcode.opmodes.setup;
 
+import com.qualcomm.robotcore.eventloop.opmode.Disabled;
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
 
 import org.firstinspires.ftc.teamcode.subassemblies.Underglow;
 import org.firstinspires.ftc.teamcode.util.Global;
 
+@Disabled
 @TeleOp(name = "Set Alliance Red", group = Global.OpModeGroup.SETUP)
 public class SetAllianceRed extends LinearOpMode {
     @Override

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/teleop/BasicTeleOp.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/teleop/BasicTeleOp.java
@@ -1,5 +1,6 @@
 package org.firstinspires.ftc.teamcode.opmodes.teleop;
 
+import com.qualcomm.robotcore.eventloop.opmode.Disabled;
 import com.qualcomm.robotcore.eventloop.opmode.OpMode;
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
 
@@ -11,6 +12,7 @@ import org.firstinspires.ftc.teamcode.subassemblies.Underglow;
 import org.firstinspires.ftc.teamcode.util.Global;
 import org.firstinspires.ftc.teamcode.util.MathEx;
 
+@Disabled
 @TeleOp(group = Global.OpModeGroup.MAIN)
 public class BasicTeleOp extends OpMode {
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/teleop/FieldCentricTeleOp.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/teleop/FieldCentricTeleOp.java
@@ -1,5 +1,6 @@
 package org.firstinspires.ftc.teamcode.opmodes.teleop;
 
+import com.qualcomm.robotcore.eventloop.opmode.Disabled;
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
 
@@ -9,6 +10,7 @@ import org.firstinspires.ftc.teamcode.subassemblies.autonomous.localizers.Limeli
 import org.firstinspires.ftc.teamcode.subassemblies.autonomous.localizers.PinpointOdo;
 import org.firstinspires.ftc.teamcode.util.Global;
 
+@Disabled
 @TeleOp(group = Global.OpModeGroup.EXPLORATORY)
 public class FieldCentricTeleOp extends LinearOpMode {
     @Override

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/teleop/SemiAutoTeleOp.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/teleop/SemiAutoTeleOp.java
@@ -145,6 +145,12 @@ public class SemiAutoTeleOp extends OpMode implements DashOpMode {
         } else if (gamepad2.rightStickButtonWasPressed()) {
             spindexer.emptyActiveSlot();
             launcher.cancelLaunches();
+        } else if (gamepad2.leftStickButtonWasPressed()) {
+            // if the kicker is stuck inside the spindexer, we need to release the pressure
+            // and retract the kicker.
+            // after that, the driver should be able to re-do whatever action needs to be done.
+            spindexer.stop();
+            launcher.unkick();
         }
 
         if (gamepad2.dpadUpWasPressed()) {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/teleop/SemiAutoTeleOp.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/teleop/SemiAutoTeleOp.java
@@ -85,11 +85,16 @@ public class SemiAutoTeleOp extends OpMode implements DashOpMode {
 
     @Override
     public void loop() {
+
         double dt = time - prevTime;
         prevTime = time;
 
         drawing.prep();
         drawing.drawPoint(GOAL_POSE, "purple");
+
+        if (Global.motif == null) {
+            limelightCam.searchForMotif();
+        }
 
         // ################   GAMEPAD 1   ################
         /*else if (gamepad1.left_bumper || gamepad1.right_stick_button) { // start goal tracking
@@ -102,24 +107,24 @@ public class SemiAutoTeleOp extends OpMode implements DashOpMode {
             underglow.setColor(IDLE_COLOR);
         } TODO commented because there is some PID feedback loop happening somewhere*/
 
-        if (gamepad1.dpadUpWasPressed()) {
+        if (/*gamepad1.dpadUpWasPressed()*/false) {
             navigator.setUnspecificTargetPose(FAR_LAUNCH_POSE);
             startAutoMovement();
             spindexer.alignAnyForLaunch();
-        } else if (gamepad1.dpadDownWasPressed()) {
+        } else if (/*gamepad1.dpadDownWasPressed()*/false) {
             navigator.setUnspecificTargetPose(CLOSE_LAUNCH_POSE);
             startAutoMovement();
             spindexer.alignAnyForLaunch();
         }
 
-        if (!gamepad1.atRest()) {
+        if (/*!gamepad1.atRest() && autoMovementEnabled*/false) {
             stopAutoMovement();
         }
 
-        if (goalTrackingEnabled) {
+        if (/*goalTrackingEnabled*/false) {
             driveBase.moveRobot(gamepad1.left_stick_x, -gamepad1.left_stick_y, navigator.getTrackingPower());
         }
-        if (!autoMovementEnabled && !goalTrackingEnabled) {
+        if (/*!autoMovementEnabled && !goalTrackingEnabled*/true) {
             driveBase.control(gamepad1);
         }
 
@@ -163,6 +168,8 @@ public class SemiAutoTeleOp extends OpMode implements DashOpMode {
             launcher.setTargetVelocity(0);
             launcher.setHoodAngle(0);
         }
+
+        spindexer.manualOffset += -gamepad2.left_stick_x * 2;
 
         // INTAKE MODE
         if (gamepad2.dpadLeftWasPressed()) {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subassemblies/Launcher.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subassemblies/Launcher.java
@@ -104,6 +104,11 @@ public class Launcher extends Subassembly {
         }
     }
 
+    public void start() {
+        kickerServo.close();
+        gateServo.close();
+    }
+
     public void update() {
 
         if (Global.ENABLE_TUNING_MODE) flywheelPIDF.setPIDF(kP, kI, kD, kF);

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subassemblies/Launcher.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subassemblies/Launcher.java
@@ -49,9 +49,9 @@ public class Launcher extends Subassembly {
 
     public static double KICKER_RANGE_MIN = 0.03;
     public static double KICKER_RANGE_MAX = 0.25;
-    public static int KICKER_EXTENSION_TIME = 250; // milliseconds
+    public static int KICKER_EXTENSION_TIME = 200; // milliseconds
 
-    public static int STUCK_DETECTION_TIME = 1500; // milliseconds
+    public static int STUCK_DETECTION_TIME = 1000; // milliseconds
     public static int SPINDEXER_MOVEMENT_DELAY = 400;
 
     private final Spindexer spindexer;
@@ -257,6 +257,11 @@ public class Launcher extends Subassembly {
         kickerServo.open();
         spindexerMovementDeadline.reset();
         kickerDeadline.reset();
+    }
+    public void unkick() {
+        kickerServo.close();
+        kickerDeadline.expire();
+        spindexerMovementDeadline.expire();
     }
 
     public void setTargetVelocity(double rpm) {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subassemblies/Spindexer.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subassemblies/Spindexer.java
@@ -41,6 +41,8 @@ public class Spindexer extends Subassembly {
     public static int SPINDEXER_MOVEMENT_DELAY = 400;
     public static int INTAKE_DEADLINE = 300; // ms
 
+    public double manualOffset = 0;
+
     private final Artifact[] drum = new Artifact[3];
 
     private final Intake intake;
@@ -272,7 +274,7 @@ public class Spindexer extends Subassembly {
     }
 
     private double getDistanceFromIndex(int slotIndex) {
-        double indexAngle = baseAngle + (slotIndex * 120);
+        double indexAngle = baseAngle + (slotIndex * 120) + manualOffset;
         double currentAngle = getCurrentAngle();
         double distance = (currentAngle - indexAngle) % 360;
 


### PR DESCRIPTION
Added a control to try to unstick the kicker.  It occasionally gets caught still inside the drum and then blocks the indexing of the spindexer.  The left stick button on Gamepad 2 now stops the motor and retracts the kicker.

I also changed the timing of the kicker and the stuck timer - I think we were a little more aggressive with those changes during the week but they didn't get made in the code, only in the dashboard as we tested.  So I didn't want to go too far.

This code has been loaded onto the robot without the Sloth loader.  If it works well in competition, we can merge it.